### PR TITLE
Video Layout Changes, Updates to Navigation Bar

### DIFF
--- a/assets/sass/styles/layouts.scss
+++ b/assets/sass/styles/layouts.scss
@@ -53,7 +53,11 @@
     }
 
     grid-auto-rows: auto;
-    grid-gap: 55px;
+    grid-gap: 24px;
+    text-align: start;
+    margin-left: 24px;
+    margin-right: 24px;
+
 }
 
 .layout-image-text {

--- a/components/Site/NavPrimary.vue
+++ b/components/Site/NavPrimary.vue
@@ -2,7 +2,7 @@
   <nav class="nav-primary">
     <ul>
       <li><nuxt-link to="/offerings">Offerings</nuxt-link></li>
-      <li><nuxt-link to="/learn">Learn</nuxt-link></li>
+      <li><nuxt-link to="/video-library">Videos</nuxt-link></li>
       <li><nuxt-link to="/journal">Journal</nuxt-link></li>
     </ul>
   </nav>

--- a/components/Video/Thumbnail.vue
+++ b/components/Video/Thumbnail.vue
@@ -14,9 +14,7 @@
         </figcaption>
       </div>
 
-      <div class="text-wrapper text-center">
-        <h3 v-if="item.title">{{ item.title }}</h3>
-      </div>
+      <div v-if="item.title" class="video-title" >{{ item.title }}</div>
     </div>
   </div>
 </template>
@@ -125,5 +123,10 @@ export default {
       line-height: 140%;
     }
   }
+}
+
+.video-title {
+    padding-left: 3px;
+    font-size: 18px;
 }
 </style>


### PR DESCRIPTION
Adds left/right margins to the video layout and decreases the gap between videos. Video titles are now aligned to the left of the video and the font size is larger.

"Learn" has been renamed "Videos." Videos will now appear on the navigation bar at the top of each page. 